### PR TITLE
get/put text from the source application to/from macvim

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -23,12 +23,16 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
 
   # copy text of current application
   osascript -e 'tell application "System Events" to tell (name of application processes whose frontmost is true) to keystroke "ac" using {command down}'
+  # store current application
+  focused=$(osascript -e 'tell application "System Events" to copy (name of application processes whose frontmost is true) to stdout')
   # add copied text to our file
   pbpaste >> $file
   # start MacVim but don't fork (this will block until you finish editing)
   /usr/local/bin/mvim --nofork $file
   # copy the result and refocus the previous application
   pbcopy < $file
+  # refocus original app
+  osascript -e "tell application $focused to activate"
   # copy back to the previous application
   osascript -e 'tell application "System Events" to tell (name of application processes whose frontmost is true) to keystroke "v" using {command down}'
 fi


### PR DESCRIPTION
For me, there is no use for refocus.scpt since when I close MacVim, I get already to the previous app.
Using this information, I copy the text of the currently active text box to use as basis for MacVim, and when I finish, I copy back.

Haven't tried this out for that many apps, in some cases "select-all" might not be a very good option, but I don't have any other idea…

Moreover "System Events" requires accessibility features to be activated…

BTW, removed a [useless use of cat](https://en.wikipedia.org/wiki/Cat_%28Unix%29#Useless_use_of_cat)
