### PR TITLE
Use ~/.gvimrc.min or ~/.vimrc.min if one exists

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -78,3 +78,6 @@ elif [[ $OSTYPE == "darwin"* ]]; then
   pbcopy < $TMPFILE
   osascript -e "activate application \"$app\""
 fi
+
+# Delete temporary files older than 60 minutes
+find $TMPFILE_DIR -name "doc-*" -type f -mtime +60m -exec srm --simple -- {} +


### PR DESCRIPTION
## Use ~/.gvimrc.min or ~/.vimrc.min if one exists

This option is useful if you want to use a minimal version of .vimrc and improve startup time
For example, my `.vimrc.min` only consists of built-in features (no plugins)
https://github.com/daeyun/dotfiles/blob/master/.vimrc.min
## Clean up $TMPFILE_DIR
1. Delete files older than 60 minutes
2. Overwrite once before deleting as a basic security measure
