### PR TITLE
Use ~/.gvimrc.min or ~/.vimrc.min if one exists.

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -38,6 +38,17 @@ done
 AW_PATH=$HOME/.vim-anywhere
 TMPFILE_DIR=/tmp/vim-anywhere
 TMPFILE=$TMPFILE_DIR/doc-$(date +"%y%m%d%H%M%S")
+VIM_OPTS=--nofork
+
+# Use ~/.gvimrc.min or ~/.vimrc.min if one exists
+VIMRC_PATH=($HOME/.gvimrc.min $HOME/.vimrc.min)
+
+for vimrc_path in "${VIMRC_PATH[@]}"; do
+    if [ -f $vimrc_path ]; then
+        VIM_OPTS+=" -u $vimrc_path"
+        break
+    fi
+done
 
 mkdir -p $TMPFILE_DIR
 touch $TMPFILE
@@ -45,7 +56,7 @@ touch $TMPFILE
 # Linux
 if [[ $OSTYPE == "linux-gnu" ]]; then
   chmod o-r $TMPFILE # Make file only readable by you
-  gvim --nofork $TMPFILE
+  gvim $VIM_OPTS $TMPFILE
   cat $TMPFILE | xclip -selection clipboard
 
 # OSX
@@ -61,7 +72,7 @@ elif [[ $OSTYPE == "darwin"* ]]; then
     "mvim must have been move or uninstalled.\nPlease make sure it is" \
     "available in your path and then reinstall vim-anywhere."
 
-  $mvim_path --nofork $TMPFILE
+  $mvim_path $VIM_OPTS $TMPFILE
   # todo, fix invalid file
   pbcopy < $TMPFILE
   osascript -e "activate application \"$app\""


### PR DESCRIPTION
This option is useful if you want to use a minimal version of `.vimrc` and improve startup time.
For example, my `.vimrc.min` only consists of built-in features (no plugins).
https://github.com/daeyun/dotfiles/blob/master/.vimrc.min
