### PR TITLE
Explicitly set $LANG variable to unicode before coping text

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -74,6 +74,6 @@ elif [[ $OSTYPE == "darwin"* ]]; then
 
   $mvim_path $VIM_OPTS $TMPFILE
   # todo, fix invalid file
-  pbcopy < $TMPFILE
+  LANG=en_US.UTF-8 pbcopy < $TMPFILE
   osascript -e "activate application \"$app\""
 fi


### PR DESCRIPTION
Looks like the system-wide $LANG value doesn't set when calling `pbcopy`
from shell. By forcing it before the command makes the `pbcopy` respect
unicode characters.

Closes #23 and possible closes #49.