### PR TITLE
Correct i3wm keybinding command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ $ gconftool -t str --set /desktop/gnome/keybindings/vim-anywhere/binding <custom
 *I3WM*
 
 ```bash
-$ bindsym $mod+Alt+v exec ~/.vim-anywhere/bin/run" >> ~/.i3/config # remember to reload your config after
+$ echo "bindsym $mod+Alt+v exec ~/.vim-anywhere/bin/run" >> ~/.i3/config # remember to reload your config after
 ```
+Adjust in case `$mod` is not set to ctrl.
 
 ## History
 


### PR DESCRIPTION
The i3wm shell command was incomplete (echo " missing).