### PR TITLE
-c option for vim-anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,15 @@ $ gconftool -t str --set /desktop/gnome/keybindings/vim-anywhere/binding <custom
 
 *I3WM*
 
+This allows the use of $mod + Alt + v to open vim for editing:
 ```bash
-$ bindsym $mod+Alt+v exec ~/.vim-anywhere/bin/run" >> ~/.i3/config # remember to reload your config after
+$ echo "bindsym $mod+Mod1+v exec ~/.vim-anywhere/bin/run" >> ~/.i3/config # remember to reload your config after
 ```
-
+On some installations (e.g., Arch), the i3 config file may be at ~/.config/i3/config.
+The following (adding Shift) allows you to start the vim session with the contents of the clipboard already open (which is useful if you would like to edit the contents of a text field):
+```bash
+$ echo "bindsym $mod+Mod1+Shift+v exec ~/.vim-anywhere/bin/run -c" >> ~/.i3/config # remember to reload your config after
+```
 ## History
 
 vim-anywhere creates a temporary file in `/tmp/vim-anywhere` when

--- a/bin/run
+++ b/bin/run
@@ -29,10 +29,12 @@ while getopts ":v:c" opt; do
     v) set -x ;;
     # This can be used to read the clipboard to the temp file
     # before Vim starts:
-    c) READ_CLIPBOARD=1;;
+    c) READ_CLIPBOARD="yes";;
     \?) echo "Invalid option: -$OPTARG" >&2 ;;
   esac
 done
+
+echo $READ_CLIPBOARD
 
 ###
 # run
@@ -59,6 +61,10 @@ touch $TMPFILE
 # Linux
 if [[ $OSTYPE == "linux-gnu" ]]; then
   chmod o-r $TMPFILE # Make file only readable by you
+  # This copies the contents of the clipboard to $TMPFILE:
+  if [[ $READ_CLIPBOARD == "yes" ]]; then
+  	xclip -o -selection clipboard > $TMPFILE
+    fi
   gvim $VIM_OPTS $TMPFILE
   cat $TMPFILE | xclip -selection clipboard
 

--- a/bin/run
+++ b/bin/run
@@ -24,9 +24,12 @@ require_file_exists() {
 # opts
 ###
 
-while getopts ":v" opt; do
+while getopts ":v:c" opt; do
   case "$opt" in
     v) set -x ;;
+    # This can be used to read the clipboard to the temp file
+    # before Vim starts:
+    c) set READ_CLIPBOARD = 1 ;;
     \?) echo "Invalid option: -$OPTARG" >&2 ;;
   esac
 done

--- a/bin/run
+++ b/bin/run
@@ -83,6 +83,7 @@ elif [[ $OSTYPE == "darwin"* ]]; then
 
   $mvim_path $VIM_OPTS $TMPFILE
   # todo, fix invalid file
+  # -c option for reading the clipboard has not yet been implemented here
   
   # NOTE
   # Here we set LANG explicitly to be UTF-8 compatible when copying text. The only way that was explicitly

--- a/bin/run
+++ b/bin/run
@@ -29,7 +29,7 @@ while getopts ":v:c" opt; do
     v) set -x ;;
     # This can be used to read the clipboard to the temp file
     # before Vim starts:
-    c) set READ_CLIPBOARD = 1 ;;
+    c) READ_CLIPBOARD=1;;
     \?) echo "Invalid option: -$OPTARG" >&2 ;;
   esac
 done


### PR DESCRIPTION
Hi Chris.  Thanks for the idea of this script: very useful!

I thought a useful addition would be to include a -c option, which copies the contents of the clipboard to the temp file before editing takes place. Thus it is possible to edit a portion of text by first "copy"-ing it to the clipboard, and hitting a new shortcut key that activates the -c option. The text opens in gvim and can be edited, and is passed back to the clipboard as usual.  Without the -c option, the script is as before.

Feel free to incorporate this into the main branch if you like.


Best regards,

Scott.