### PR TITLE
Small markup fix: lost backtick

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ curl -fsSL https://raw.github.com/cknadler/vim-anywhere/master/install | bash
 
 ## Keybinding
 
-__OSX:__ ( default = ctrl+cmd+v` )
+__OSX:__ ( default = `ctrl+cmd+v` )
 
 You can adjust the shortcut via [system preferences](assets/shortcut.png).
 


### PR DESCRIPTION
One backtick got lost with these changes:
https://github.com/cknadler/vim-anywhere/commit/9aefdb0090ec3537dbabaae0d2a9cc316fc37696#diff-04c6e90faac2675aa89e2176d2eec7d8L48