### PR TITLE
Support capital 'Darwin' $OSTYPE

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -60,7 +60,7 @@ if [[ $OSTYPE == "linux-gnu" ]]; then
   cat $TMPFILE | xclip -selection clipboard
 
 # OSX
-elif [[ $OSTYPE == "darwin"* ]]; then
+elif [[ $OSTYPE =~ [Dd]+arwin[.]* ]]; then
   # if there is no path file, it must have been deleted or the installer failed
   require_file_exists $AW_PATH/.path \
     "Please reinstall vim-anywhere."

--- a/install
+++ b/install
@@ -75,7 +75,7 @@ if [[ $OSTYPE == "linux-gnu" ]]; then
   require_installed xclip
 
 # OSX specific checks
-elif [[ $OSTYPE == "darwin"* ]]; then
+elif [[ $OSTYPE =~ [Dd]+arwin[.]* ]]; then
   require_installed mvim 'Run `brew install macvim`.'
 
 # Unsupported OS
@@ -120,7 +120,7 @@ if [[ $OSTYPE == "linux-gnu" ]]; then
   fi
 
 # OSX install
-elif [[ $OSTYPE == "darwin"* ]]; then
+elif [[ $OSTYPE =~ [Dd]+arwin[.]* ]]; then
   # store the absolute path to the mvim executable
   which mvim > $AW_PATH/.path
 

--- a/uninstall
+++ b/uninstall
@@ -49,7 +49,7 @@ if [[ $OSTYPE == "linux-gnu" ]]; then
   fi
 
 # OSX uninstall
-elif [[ $OSTYPE == "darwin"* ]]; then
+elif [[ $OSTYPE =~ [Dd]+arwin[.]* ]]; then
   rm -rf $HOME/Library/Services/VimAnywhere.workflow
 fi
 

--- a/update
+++ b/update
@@ -47,7 +47,7 @@ pushd $AW_PATH
 popd
 
 # OSX only
-if [[ $OSTYPE == "darwin"* ]]; then
+if [[ $OSTYPE =~ [Dd]+arwin[.]* ]]; then
   cp -R $AW_PATH/VimAnywhere.workflow $HOME/Library/Services
 fi
 


### PR DESCRIPTION
On some macOS environments, the `$OSTYPE` environment variable is
'Darwin' (capitalized) and not 'darwin'. This caused the install script
to echo "OS Darwin is not supported!" and exit, even if everything was
in fact in order.

This patch uses a case-insensitive regex against a [standard bash
operator](1) to allow any `$OSTYPE` that starts with 'Darwin' or
'darwin'.

All other instances of conditional checks for darwin* are also patched
across the code base.

[1]: https://www.gnu.org/software/bash/manual/bash.html#index-_005d_005d