### PR TITLE
Make the default file type markdown

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -37,7 +37,7 @@ done
 
 AW_PATH=$HOME/.vim-anywhere
 TMPFILE_DIR=/tmp/vim-anywhere
-TMPFILE=$TMPFILE_DIR/doc-$(date +"%y%m%d%H%M%S")
+TMPFILE=$TMPFILE_DIR/doc-$(date +"%y%m%d%H%M%S").md
 VIM_OPTS=--nofork
 
 # Use ~/.gvimrc.min or ~/.vimrc.min if one exists


### PR DESCRIPTION
The markdown file type is much more useful than a plain text file which is very useful for GitHub comments, issues, et cetera

I understand that this doesn't solve the problem completely because different people might want different default file types. This is a quick solution to improve upon the current state of using a plain text file, which is much less useful than any specific file type.

If any user wants to change file type quickly, I recommend setting up mappings in your vimrc (for example https://github.com/dylan-chong/dotfiles/commit/c2e3b5d5cb82d6d35101a10c29c2a0d78f683383#diff-4e12c6a37ff2cbb2c93d1b33324a6051R571)