### PR TITLE
detecting MacVim.app on installation #33

### DIFF
--- a/install
+++ b/install
@@ -75,6 +75,8 @@ if [[ $OSTYPE == "linux-gnu" ]]; then
   require_installed xclip
 
 # OSX specific checks
+elif [[ -d "/Applications/MacVim.app" ]]; then
+  true
 elif [[ $OSTYPE == "darwin"* ]]; then
   require_installed mvim 'Run `brew install macvim`.'
 
@@ -122,7 +124,11 @@ if [[ $OSTYPE == "linux-gnu" ]]; then
 # OSX install
 elif [[ $OSTYPE == "darwin"* ]]; then
   # store the absolute path to the mvim executable
-  which mvim > $AW_PATH/.path
+  if [[ -d "/Applications/MacVim.app" ]]; then
+    echo "/Applications/MacVim.app/Contents/MacOs/MacVim" > $AW_PATH/.path
+  else
+    which mvim > $AW_PATH/.path
+  fi
 
   # install the workflow as a service
   mkdir -p $HOME/Library/Services


### PR DESCRIPTION
Detect MacVim.app if it is installed and if so, proceed with installation.

If it is not installed neither an .app or through homebrew; continue to advise to install macvim through homebrew.