### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ refocused.
 
 __OSX:__
 
-- MacVim (`brew cask install macvim`)
+- MacVim (`brew install --cask macvim`)
 
 __Linux:__
 


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524